### PR TITLE
fix dependency in installing by pip

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include cuda_setup.py
 include CMakeLists.txt
 include requirements.txt
+include pyproject.toml
 include tests/res/*.json
 recursive-exclude buffalo/ *.cpp
 recursive-include buffalo/ *.pyx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=1.3.2",
+    "cython",
     "numpy",
     "n2==0.1.6"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=1.3.2",
+    "numpy",
+    "n2==0.1.6"
+]

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,8 @@ if sys.version_info[:3] < (3, 6):
 assert platform.system() == 'Linux'  # TODO: MacOS
 numpy_include_dirs = os.path.split(numpy.__file__)[0] + '/core/include'
 n2_shared_object = n2.__file__
+with open("requirements.txt", "r") as fin:
+    INSTALL_REQUIRES = [line.strip() for line in fin]
 
 MAJOR = 1
 MINOR = 2
@@ -252,6 +254,7 @@ def setup_package():
                   'buffalo/parallel/',
                   'buffalo/misc/',
                   'buffalo/'],
+        install_requires=INSTALL_REQUIRES,
         cmdclass=cmdclass,
         classifiers=[_f for _f in CLASSIFIERS.split('\n') if _f],
         platforms=['Linux', 'Mac OSX', 'Unix'],


### PR DESCRIPTION
- it might be a little annoying when installing buffalo from pip before installing n2 and numpy

```
# pip install buffalo
Collecting buffalo
  Downloading buffalo-1.2.1.tar.gz (2.6 MB)
     |################################| 2.6 MB 1.7 MB/s
    ERROR: Command errored out with exit status 1:
     command: /usr/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-6j6xdcno/buffalo_1bdabc56745146b2b2c011aa4f232db3/setup.py'"'"'; __file__='"'"'/tmp/pip-install-6j6xdcno/buffalo_1bdabc56745146b2b2c011aa4f232db3/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-5j01_aou
         cwd: /tmp/pip-install-6j6xdcno/buffalo_1bdabc56745146b2b2c011aa4f232db3/
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-6j6xdcno/buffalo_1bdabc56745146b2b2c011aa4f232db3/setup.py", line 16, in <module>
        import n2
    ModuleNotFoundError: No module named 'n2'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.**
```

- `pyproject.toml` ensures installing dependencies before running setup.py