### PR TITLE
add cmake and version up n2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,6 @@ requires = [
     "setuptools>=1.3.2",
     "cython",
     "numpy",
-    "n2==0.1.6"
+    "n2==0.1.7",
+    "cmake"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ h5py
 hyperopt
 tensorflow==1.15.2
 cython
-n2==0.1.6
+n2==0.1.7
+cmake
 pytest


### PR DESCRIPTION
@nailbrainz regarding this [issue](https://github.com/kakao/buffalo/pull/37#issuecomment-776490724) 

- version up n2 requirements
- add cmake to dependency as well
- tested on fresh venv + python3.6.9 + (pip install -U pip) => work