### PR TITLE
fix poetry build option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ Buffalo = "buffalo.cli:_cli_buffalo"
 
 [tool.poetry.build]
 script = "build_extension.py"
+generate-setup-file = true
 
 [tool.poe.tasks]
   [tool.poe.tasks.codespell]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,5 +78,5 @@ generate-setup-file = true
   sequence  = ["isort", "flake8-py", "flake8-pyx", "cpplint"]
 
 [build-system]
-requires = ["poetry-core>=1.2.0", "setuptools", "wheel", "numpy>=1.21.6", "Cython>=0.29.32", "packaging>=22.0"]
+requires = ["poetry-core==1.5.0", "setuptools", "wheel", "numpy>=1.21.6", "Cython>=0.29.32", "packaging>=22.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
- poetry가 3일전에 새로 릴리즈 되었는데([1.5.0](https://github.com/python-poetry/poetry-core/releases/tag/1.5.0)) 이 릴리즈 이후부터`build.generate-setup-file` 값이 `true` -> `false`로 바뀌었습니다.
- `true`인 경우 setup.py 자동 생성 -> build_extension.py에 정의한대로 cython 빌드 과정 추가 -> setup.py에서 setuptools.setup 함수로 cython 빌드 와 같은 과정을 거칩니다.
- 반면 `false`인 경우 setup.py를 자동생성 하지 않습니다. 따라서 build_extension.py에 정의한 cython 빌드 과정이 무시되고 결과적으로 cython 빌드가 안됩니다.
- 아마 이게 이기가 말씀하셨던 cython 컴파일 안되는 원인인듯 합니다.
- build_extension.py 에 `if __name__ == '__main__'` 섹션을 따로 만들어서 아예 여기서 cython 빌드가 되도록 하면 되긴 하는데, 약간 변경 사항이 많아질듯 하여 우선은 기존 방식 그대로(setup.py 생성 -> build_extension.py에서 cython 빌드 과정 추가 -> setup.py로 cython 빌드) 적용하기 위해 `generate-setup-file` 옵션을 `true`로 명시했습니다.