### PR TITLE
bug fix: progress bar in log.py

### DIFF
--- a/buffalo/misc/log.py
+++ b/buffalo/misc/log.py
@@ -141,11 +141,15 @@ class ProgressBar(object):
             cnts += 1
             self.step += 1
             if period_iter != 0 and (cnts % period_iter == 0):
+                self.t = time.time()
                 self.logger(self.get_msg())
             else:
-                delta = time.time() - self.s_t
+                t = time.time()
+                delta = t - self.t
                 if delta > self.period_secs:
                     period_iter = cnts
+                    self.t = t
+                    self.logger(self.get_msg())
         if self.total != -1:
             self.step = self.total
         self.logger(self.get_msg() + "\n")


### PR DESCRIPTION
### 현재
- delta = time.time - **self.s_t**
- iter 한 바퀴를 도는 시간이 self.period_secs보다 작으면, progress bar가 출력되지 않음
  - `cnts`는 항상 `period_iter + 1`이므로, `cnts % period_iter = 1`이 됨
- 참고) iter가 아니라 update로 실행하면 정상 출력

### 변경
- self.t를 업데이트해주고, delta를 `이전 출력 시간과 현재 시간의 차`로 변경