### PR TITLE
fix bug during w2v training with utf8 characters

### DIFF
--- a/buffalo/data/base.py
+++ b/buffalo/data/base.py
@@ -203,7 +203,7 @@ class Data(object):
         idmap = f.create_group("idmap")
         idmap.create_dataset("rows", (num_users,), dtype="S%s" % uid_max_col,
                              maxshape=(num_users,))
-        idmap.create_dataset("cols", (num_items,), dtype="S%s" % iid_max_col,
+        idmap.create_dataset("cols", (num_items,), dtype=h5py.string_dtype('utf-8', length=iid_max_col),
                              maxshape=(num_items,))
         return f
 

--- a/buffalo/data/stream.py
+++ b/buffalo/data/stream.py
@@ -148,7 +148,7 @@ class Stream(Data):
             else:
                 cols = sorted(itemids.items(), key=lambda x: x[1])
                 cols = [k for k, _ in cols]
-                idmap["cols"][:] = np.array(cols, dtype=f"S{iid_max_col}")
+                idmap["cols"][:] = cols
         except Exception as e:
             self.logger.error("Cannot create db: %s" % (str(e)))
             self.logger.error(traceback.format_exc())


### PR DESCRIPTION
### bug
when training w2v with Korean words(`utf-8` characters), `idmap['cols']` couldn't get utf-8

```
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-1: ordinal not in range(128)
```

#### as-is
- `dtype=Sx`
  - S: data type should be ascii characters

#### to be
- `dtype=h5py.string_dtype('utf-8')`
  - [docs](https://docs.h5py.org/en/stable/special.html#h5py.string_dtype)