### PR TITLE
fix bug during w2v training with utf8 characters

### DIFF
--- a/buffalo/data/base.py
+++ b/buffalo/data/base.py
@@ -203,7 +203,7 @@ class Data(object):
         idmap = f.create_group("idmap")
         idmap.create_dataset("rows", (num_users,), dtype="S%s" % uid_max_col,
                              maxshape=(num_users,))
-        idmap.create_dataset("cols", (num_items,), dtype="S%s" % iid_max_col,
+        idmap.create_dataset("cols", (num_items,), dtype=h5py.string_dtype('utf-8', length=iid_max_col),
                              maxshape=(num_items,))
         return f
 

--- a/buffalo/data/base.py
+++ b/buffalo/data/base.py
@@ -201,7 +201,7 @@ class Data(object):
         iid_max_col = kwargs["iid_max_col"]
         uid_max_col = kwargs["uid_max_col"]
         idmap = f.create_group("idmap")
-        idmap.create_dataset("rows", (num_users,), dtype="S%s" % uid_max_col,
+        idmap.create_dataset("rows", (num_users,), dtype=h5py.string_dtype("utf-8", length=uid_max_col),
                              maxshape=(num_users,))
         idmap.create_dataset("cols", (num_items,), dtype=h5py.string_dtype("utf-8", length=iid_max_col),
                              maxshape=(num_items,))

--- a/buffalo/data/base.py
+++ b/buffalo/data/base.py
@@ -203,7 +203,7 @@ class Data(object):
         idmap = f.create_group("idmap")
         idmap.create_dataset("rows", (num_users,), dtype="S%s" % uid_max_col,
                              maxshape=(num_users,))
-        idmap.create_dataset("cols", (num_items,), dtype=h5py.string_dtype('utf-8', length=iid_max_col),
+        idmap.create_dataset("cols", (num_items,), dtype=h5py.string_dtype("utf-8", length=iid_max_col),
                              maxshape=(num_items,))
         return f
 

--- a/buffalo/data/stream.py
+++ b/buffalo/data/stream.py
@@ -121,7 +121,7 @@ class Stream(Data):
                 itemids = {iid.strip(): idx + 1 for idx, iid in enumerate(fin)}
         else:  # in case of item information is not given
             itemids = {i: idx + 1 for idx, i in enumerate(itemids)}
-        iid_max_col = max(len(k) + 1 for k in itemids.keys())
+        iid_max_col = max(len(k.encode()) + 1 for k in itemids.keys())
         num_items = len(itemids)
 
         self.logger.info("Found %d unique itemids" % len(itemids))

--- a/buffalo/data/stream.py
+++ b/buffalo/data/stream.py
@@ -84,7 +84,7 @@ class Stream(Data):
             with open(fname) as fin:
                 max_col = 0
                 for l in fin:
-                    max_col = max(max_col, len(l))
+                    max_col = max(max_col, len(l.encode()))
             return max_col
         uid_path, iid_path, main_path = P["uid_path"], P["iid_path"], P["main_path"]
         if uid_path:
@@ -138,13 +138,14 @@ class Stream(Data):
             # if not given, assume id as is
             if uid_path:
                 with open(uid_path) as fin:
-                    idmap["rows"][:] = np.loadtxt(fin, dtype=f"S{uid_max_col}")
+                    rows = [line.strip() for line in fin.readlines()]
+                idmap["rows"][:] = rows
             else:
-                idmap["rows"][:] = np.array([str(i) for i in range(1, num_users + 1)],
-                                            dtype=f"S{uid_max_col}")
+                idmap["rows"][:] = [str(i) for i in range(1, num_users + 1)]
             if iid_path:
                 with open(iid_path) as fin:
-                    idmap["cols"][:] = np.loadtxt(fin, dtype=f"S{iid_max_col}")
+                    cols = [line.strip() for line in fin.readlines()]
+                idmap["cols"][:] = cols
             else:
                 cols = sorted(itemids.items(), key=lambda x: x[1])
                 cols = [k for k, _ in cols]

--- a/buffalo/data/stream.py
+++ b/buffalo/data/stream.py
@@ -4,7 +4,6 @@ import warnings
 from collections import Counter
 
 import h5py
-import numpy as np
 import psutil
 
 from buffalo.data.base import Data, DataOption

--- a/buffalo/data/stream.py
+++ b/buffalo/data/stream.py
@@ -148,7 +148,7 @@ class Stream(Data):
             else:
                 cols = sorted(itemids.items(), key=lambda x: x[1])
                 cols = [k for k, _ in cols]
-                idmap["cols"][:] = np.array(cols, dtype=f"S{iid_max_col}")
+                idmap["cols"][:] = cols
         except Exception as e:
             self.logger.error("Cannot create db: %s" % (str(e)))
             self.logger.error(traceback.format_exc())

--- a/tests/data/test_stream.py
+++ b/tests/data/test_stream.py
@@ -17,6 +17,9 @@ class TestStream(unittest.TestCase):
         with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
             f.write("""사과 망고 망고 사과 파이 주스 콜라\n파이\n주스 콜라 포도""")
             cls.unicode_main_path = f.name
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+            f.write("""김씨\n이씨\n박씨""")
+            cls.unicode_uid_path = f.name
         cls.temp_files = []
 
     @classmethod
@@ -90,7 +93,7 @@ class TestStream(unittest.TestCase):
     def test4_unicode(self):
         opt = StreamOptions().get_default_option()
         opt.input.main = self.unicode_main_path
-        opt.input.uid = self.uid_path
+        opt.input.uid = self.unicode_uid_path
         mm = Stream(opt)
         mm.create()
         self.assertTrue(True)


### PR DESCRIPTION
### bug
when training w2v with Korean words(`utf-8` characters), `idmap['cols']` couldn't get utf-8

```
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-1: ordinal not in range(128)
```

#### as-is
- `dtype=Sx`
  - S: data type should be ascii characters

#### to be
- `dtype=h5py.string_dtype('utf-8')`
  - [docs](https://docs.h5py.org/en/stable/special.html#h5py.string_dtype)