### PR TITLE
Fix W2V stream data newline error.

### DIFF
--- a/buffalo/data/fileio.hpp
+++ b/buffalo/data/fileio.hpp
@@ -322,7 +322,7 @@ vector<string> _sort_and_compressed_binarization(
         records.insert(end(records), begin(v), end_it);
     }
 
-    assert(records.size == total_lines);
+    assert(records.size() == total_lines);
 
     omp_set_num_threads(num_workers);
 

--- a/buffalo/data/stream.py
+++ b/buffalo/data/stream.py
@@ -105,6 +105,8 @@ class Stream(Data):
         with open(main_path) as fin:
             for line in log.ProgressBar(level=log.DEBUG, iterable=fin):
                 data = line.strip().split()
+                if not data:
+                    continue
                 if not iid_path:
                     itemids |= set(data)
 
@@ -246,7 +248,7 @@ class Stream(Data):
                         for col in train_data:
                             w.write(f"{user} {col} 1\n")
                         for col in vali_data:
-                            vali_lines.append(f"{user} {col} {val}")
+                            vali_lines.append(f"{user} {col} 1")
                     else:
                         for col, val in Counter(train_data).items():
                             w.write(f"{user} {col} {val}\n")


### PR DESCRIPTION
While using the W2V model, a vulnerability arises, resulting in a memory error if the input stream data contains empty lines without characters.

**Cause**
During the reading of stream data, if a line contains only a newline character, the `num_nnz` variable is incremented by 1. [code](https://github.com/kakao/buffalo/blob/v2.0.3/buffalo/data/stream.py#L111-L112)
```python3
data_size = len(data) # 0
_vali_size = min(vali_n, len(data) - 1) # -1
num_nnz += (data_size - _vali_size) # +1
```

Later on, `num_nnz` is utilized as `total_lines` in the [_sort_and_compressed_binarization()](https://github.com/kakao/buffalo/blob/v2.0.3/buffalo/data/fileio.hpp#L263) function. 
The values stored in the `path` file are pass to the `records` vector, and this vector is read based on the `total_lines`. [code](https://github.com/kakao/buffalo/blob/v2.0.3/buffalo/data/fileio.hpp#L359-L368)
If the calculation of `num_nnz` is inflated due to the newline, it exceeds the index of the `records` vector, leading to references outside the bounds. 
Consequently, reading unexpected values triggers a segment fault or program malfunction.

**Changes**
In instances where an empty line is inputted, it has been modified to be disregarded using the `continue` statement. Additionally, a typo identified during debugging has been rectified.
