### PR TITLE
add cleanup functions and typo fix

### DIFF
--- a/buffalo/misc/_aux.py
+++ b/buffalo/misc/_aux.py
@@ -140,11 +140,14 @@ def get_temporary_file(root="/tmp/", write_mode="w"):
 
 
 @atexit.register
-def __cleanup_tempory_files():
+def __cleanup_temporary_files():
     for path in _temporary_files:
         if os.path.isfile(path):
             os.remove(path)
+    _temporary_files.clear()
 
+def cleanup_temporary_files():
+    __cleanup_temporary_files()
 
 def register_cleanup_file(path):
     _temporary_files.append(path)


### PR DESCRIPTION
## 요약

- 프로그램이 종료되면서 temp file 을 제거하고 있지만, 프로그램 실행 중에도 temp file 을 제거할 수 있도록 함수 추가하였습니다.

## 배경
- buffalo.misc._aux 모듈을 사용할 때, "get_temporary_file()" 함수에 의해 temp file 이 생성됨
- 생성된 temp file 은 "__cleanup_tempory_files()" 함수에 의해 삭제됨
- "__cleanup_tempory_files()" 는 프로그램이 종료될 때 자동으로 실행됨
- 하지만, iterative 한 프로그램에서 주기적으로 제거 함수를 실행시켜주지 않으면 지속적으로 파일이 생기기만 하고 제거되지 않아 메모리가 꽉 차게 됨
- 따라서, temp file 제거를 위해 아래 변경점을 추가하였음


## 변경점

#### 1) cleanup_temporary_files() 함수 추가
- 기존 " __ cleanup_tempory_files()" 를 호출해도 되지만, buffalo.misc._aux 를 외부에서 library로 쓸 때, " __ "가 붙는 함수를 호출하는 것이 적절하지 않다고 생각하여 "__"가 빠진 함수 따로 추가하였습니다.

#### 2) _temporary_files 변수 초기화
- __cleanup_tempory_files() 가 호출되면서 "_temporary_files" 변수를 초기화하지 않고 있어서 해당 부분 추가하였습니다.
- 프로그램이 종료되면서 함수가 호출되는 경우는 상관없지만, 메모리 관리를 위해 주기적으로 호출되는 경우 변수를 초기화할 필요가 있기 때문입니다.

#### 3) 오타 수정
- 기존: __cleanup_tempory_files()
- 변경: __cleanup_temporary_files()

