### PR TITLE
Add fallback functions in case the BLAS library is missing

### DIFF
--- a/buffalo/data/mm.py
+++ b/buffalo/data/mm.py
@@ -5,6 +5,7 @@ import h5py
 import numpy as np
 import scipy.io
 import scipy.sparse
+
 from buffalo.data import prepro
 from buffalo.data.base import Data, DataOption, DataReader
 from buffalo.misc import aux, log

--- a/buffalo/data/mm.py
+++ b/buffalo/data/mm.py
@@ -5,7 +5,6 @@ import h5py
 import numpy as np
 import scipy.io
 import scipy.sparse
-
 from buffalo.data import prepro
 from buffalo.data.base import Data, DataOption, DataReader
 from buffalo.misc import aux, log
@@ -138,17 +137,17 @@ class MatrixMarket(Data):
                 # if not given, assume id as is
                 if uid_path:
                     with open(uid_path) as fin:
-                        idmap["rows"][:] = np.loadtxt(fin, dtype=f"S{uid_max_col}")
+                        idmap["rows"][:] = np.loadtxt(fin, dtype=h5py.string_dtype("utf-8", length=uid_max_col))
                 else:
                     idmap["rows"][:] = np.array([str(i) for i in range(1, num_users + 1)],
-                                                dtype=f"S{uid_max_col}")
+                                                dtype=h5py.string_dtype("utf-8", length=uid_max_col))
                 pbar.update(1)
                 if iid_path:
                     with open(iid_path) as fin:
-                        idmap["cols"][:] = np.loadtxt(fin, dtype=f"S{iid_max_col}")
+                        idmap["cols"][:] = np.loadtxt(fin, dtype=h5py.string_dtype("utf-8", length=iid_max_col))
                 else:
                     idmap["cols"][:] = np.array([str(i) for i in range(1, num_items + 1)],
-                                                dtype=f"S{iid_max_col}")
+                                                dtype=h5py.string_dtype("utf-8", length=iid_max_col))
                 pbar.update(1)
                 num_header_lines = 0
                 with open(main_path) as fin:
@@ -252,8 +251,8 @@ class MatrixMarket(Data):
         self.logger.debug("Building meta part...")
         db, num_header_lines = self._create(data_path,
                                             {"main_path": mm_main_path,
-                                                "uid_path": mm_uid_path,
-                                                "iid_path": mm_iid_path},
+                                             "uid_path": mm_uid_path,
+                                             "iid_path": mm_iid_path},
                                             header)
         try:
             num_header_lines += 1  # add metaline

--- a/include/buffalo/misc/blas.hpp
+++ b/include/buffalo/misc/blas.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <iostream>
 #include <string>
 #include <algorithm>
+#include <cctype>
 
 
 extern "C" {
@@ -15,6 +17,198 @@ void dsyrk_(const char*, const char*, const int*, const int*, const double*, con
 
 namespace blas {
 namespace impl {
+// LSAME function: Compares two characters case-insensitively
+// In Fortran BLAS, LSAME(CA, CB) is true if CA is the same letter as CB regardless of case.
+// CA and CB are CHARACTER*1.
+bool lsame(char ca, char cb) {
+    return (std::toupper(static_cast<unsigned char>(ca)) == std::toupper(static_cast<unsigned char>(cb)));
+}
+
+// XERBLA error handler (basic version)
+void xerbla(const std::string& srname, int info) {
+    std::cerr << "** On entry to " << srname
+              << " parameter number " << info
+              << " had an illegal value" << std::endl;
+    // In a real BLAS library, this might call exit() or throw an exception.
+    exit(EXIT_FAILURE);
+}
+
+template <typename T>
+void csyrk(char uplo, char trans, int n, int k, T alpha,
+           const T* a, int lda, T beta, T* c, int ldc) {
+    // Parameters
+    const T one = 1.0f;
+    const T zero = 0.0f;
+
+    // Local Scalars
+    T temp;
+    int i, info, j, l; // Fortran i, info, j, l (loop counters)
+    int nrowa;
+    bool upper;
+
+    // Test the input parameters.
+    if (lsame(trans, 'N')) {
+        nrowa = n;
+    } else {
+        nrowa = k;
+    }
+    upper = lsame(uplo, 'U');
+
+    info = 0;
+    if (!upper && !lsame(uplo, 'L')) {
+        info = 1;
+    } else if (!lsame(trans, 'N') &&
+               !lsame(trans, 'T') &&
+               !lsame(trans, 'C')) {
+        info = 2;
+    } else if (n < 0) {
+        info = 3;
+    } else if (k < 0) {
+        info = 4;
+    } else if (lda < std::max(1, nrowa)) {
+        info = 7;
+    } else if (ldc < std::max(1, n)) {
+        info = 10;
+    }
+
+    if (info != 0) {
+        xerbla("SSYRK ", info);
+    }
+
+    // Quick return if possible.
+    if (n == 0 || ((alpha == zero || k == 0) && beta == one)) {
+        return;
+    }
+
+    // And when alpha.eq.zero.
+    if (alpha == zero) {
+        if (upper) {
+            if (beta == zero) {
+                for (j = 0; j < n; ++j) { // Fortran J = 1, N
+                    for (i = 0; i <= j; ++i) { // Fortran I = 1, J
+                        c[j * ldc + i] = zero; // c(i,j)
+                    }
+                }
+            } else {
+                for (j = 0; j < n; ++j) { // Fortran J = 1, N
+                    for (i = 0; i <= j; ++i) { // Fortran I = 1, J
+                        c[j * ldc + i] = beta * c[j * ldc + i]; // c(i,j)
+                    }
+                }
+            }
+        } else { // Lower triangular
+            if (beta == zero) {
+                for (j = 0; j < n; ++j) { // Fortran J = 1, N
+                    for (i = j; i < n; ++i) { // Fortran I = J, N
+                        c[j * ldc + i] = zero; // c(i,j)
+                    }
+                }
+            } else {
+                for (j = 0; j < n; ++j) { // Fortran J = 1, N
+                    for (i = j; i < n; ++i) { // Fortran I = J, N
+                        c[j * ldc + i] = beta * c[j * ldc + i]; // c(i,j)
+                    }
+                }
+            }
+        }
+        return;
+    }
+
+    // Start the operations.
+    // C++ indexing: array[col_idx * leading_dim + row_idx]
+    // Fortran: C(row_idx_1based, col_idx_1based)
+    //          A(row_idx_1based, col_idx_1based)
+    // Here, C++ loop variables i, j, l are 0-based.
+    // i typically corresponds to Fortran row index, j to Fortran column index.
+
+    if (lsame(trans, 'N')) {
+        // Form  C := alpha*A*A**T + beta*C.
+        // A is N x K (nrowa = N)
+        // A(j,l) in Fortran means A[ (l-1)*lda + (j-1) ]
+        // A(i,l) in Fortran means A[ (l-1)*lda + (i-1) ]
+        if (upper) {
+            for (j = 0; j < n; ++j) { // Fortran J = 1, N (column of C)
+                if (beta == zero) {
+                    for (i = 0; i <= j; ++i) { // Fortran I = 1, J (row of C)
+                        c[j * ldc + i] = zero;
+                    }
+                } else if (beta != one) {
+                    for (i = 0; i <= j; ++i) {
+                        c[j * ldc + i] *= beta;
+                    }
+                }
+                for (l = 0; l < k; ++l) { // Fortran L = 1, K (column of A, row of A**T)
+                    // A is N x K. Fortran A(j,l) corresponds to element at row j, col l.
+                    // C++ access: a[l*lda + j] (0-based indices)
+                    if (a[l * lda + j] != zero) { // Fortran A(j+1, l+1)
+                        temp = alpha * a[l * lda + j];
+                        for (i = 0; i <= j; ++i) { // Fortran I = 1, J (row of C)
+                            c[j * ldc + i] += temp * a[l * lda + i]; // Fortran A(i+1, l+1)
+                        }
+                    }
+                }
+            }
+        } else { // Lower triangular
+            for (j = 0; j < n; ++j) { // Fortran J = 1, N (column of C)
+                if (beta == zero) {
+                    for (i = j; i < n; ++i) { // Fortran I = J, N (row of C)
+                        c[j * ldc + i] = zero;
+                    }
+                } else if (beta != one) {
+                    for (i = j; i < n; ++i) {
+                        c[j * ldc + i] *= beta;
+                    }
+                }
+                for (l = 0; l < k; ++l) { // Fortran L = 1, K
+                    if (a[l * lda + j] != zero) { // Fortran A(j+1, l+1)
+                        temp = alpha * a[l * lda + j];
+                        for (i = j; i < n; ++i) { // Fortran I = J, N (row of C)
+                            c[j * ldc + i] += temp * a[l * lda + i]; // Fortran A(i+1, l+1)
+                        }
+                    }
+                }
+            }
+        }
+    } else { // trans == 'T' or 'C'
+        // Form  C := alpha*A**T*A + beta*C.
+        // A is K x N (nrowa = K)
+        // Fortran A(l,i) means A[ (i-1)*lda + (l-1) ]
+        // Fortran A(l,j) means A[ (j-1)*lda + (l-1) ]
+        if (upper) {
+            for (j = 0; j < n; ++j) { // Fortran J = 1, N (column of C, also column of A)
+                for (i = 0; i <= j; ++i) { // Fortran I = 1, J (row of C, also column of A)
+                    temp = zero;
+                    // A is K x N. Fortran A(l,i) corresponds to element at row l, col i.
+                    // C++ access: a[i*lda + l] (0-based indices)
+                    for (l = 0; l < k; ++l) { // Fortran L = 1, K (row of A)
+                        temp += a[i * lda + l] * a[j * lda + l]; // Fortran A(l+1,i+1) * A(l+1,j+1)
+                    }
+                    if (beta == zero) {
+                        c[j * ldc + i] = alpha * temp;
+                    } else {
+                        c[j * ldc + i] = alpha * temp + beta * c[j * ldc + i];
+                    }
+                }
+            }
+        } else { // Lower triangular
+            for (j = 0; j < n; ++j) { // Fortran J = 1, N
+                for (i = j; i < n; ++i) { // Fortran I = J, N
+                    temp = zero;
+                    for (l = 0; l < k; ++l) { // Fortran L = 1, K
+                        temp += a[i * lda + l] * a[j * lda + l]; // Fortran A(l+1,i+1) * A(l+1,j+1)
+                    }
+                    if (beta == zero) {
+                        c[j * ldc + i] = alpha * temp;
+                    } else {
+                        c[j * ldc + i] = alpha * temp + beta * c[j * ldc + i];
+                    }
+                }
+            }
+        }
+    }
+}
+
+
 inline void syrk(const char uplo,
                  const char trans,
                  const int n,
@@ -25,7 +219,11 @@ inline void syrk(const char uplo,
                  const float beta,
                  float* C,
                  const int ldc) {
+#ifdef BUFFALO_USE_BLAS
     ssyrk_(&uplo, &trans, &n, &k, &alpha, A, &lda, &beta, C, &ldc);
+#else
+    csyrk<float>(uplo, trans, n, k, alpha, A, lda, beta, C, ldc);
+#endif
 }
 
 inline void syrk(const char uplo,
@@ -38,7 +236,11 @@ inline void syrk(const char uplo,
                  const double beta,
                  double* C,
                  const int ldc) {
+#ifdef BUFFALO_USE_BLAS
     dsyrk_(&uplo, &trans, &n, &k, &alpha, A, &lda, &beta, C, &ldc);
+#else
+    csyrk<double>(uplo, trans, n, k, alpha, A, lda, beta, C, ldc);
+#endif
 }
 } // end namespace impl
 

--- a/include/buffalo/misc/blas.hpp
+++ b/include/buffalo/misc/blas.hpp
@@ -20,12 +20,12 @@ namespace impl {
 // LSAME function: Compares two characters case-insensitively
 // In Fortran BLAS, LSAME(CA, CB) is true if CA is the same letter as CB regardless of case.
 // CA and CB are CHARACTER*1.
-bool lsame(char ca, char cb) {
+inline bool lsame(char ca, char cb) {
     return (std::toupper(static_cast<unsigned char>(ca)) == std::toupper(static_cast<unsigned char>(cb)));
 }
 
 // XERBLA error handler (basic version)
-void xerbla(const std::string& srname, int info) {
+inline void xerbla(const std::string& srname, int info) {
     std::cerr << "** On entry to " << srname
               << " parameter number " << info
               << " had an illegal value" << std::endl;

--- a/install/locate_blas.py
+++ b/install/locate_blas.py
@@ -5,8 +5,6 @@ from typing import Optional
 BLAS_LIB_NAMES = [
     "openblas",  # OpenBLAS
     "mkl_rt",  # Intel MKL (runtime)
-    "Accelerate",  # macOS Accelerate Framework (often found as part of System)
-    "vecLib",  # Also macOS, part of Accelerate
     "blas",  # Generic
 ]
 

--- a/install/locate_blas.py
+++ b/install/locate_blas.py
@@ -39,10 +39,10 @@ def _locate_blas() -> Optional[str]:
 
     if loaded_lib:
         try:
-            ssyrk_func = getattr(loaded_lib, "ssyrk_")  # Note the trailing underscore
+            ssyrk_func = getattr(loaded_lib, "ssyrk_")  # Note the trailing underscore # noqa: F841
         except AttributeError:
             try:
-                ssyrk_func = getattr(loaded_lib, "cblas_ssyrk")  # cblas interface
+                ssyrk_func = getattr(loaded_lib, "cblas_ssyrk")  # cblas interface # noqa: F841
             except AttributeError:
                 pass
     return found_lib

--- a/install/locate_blas.py
+++ b/install/locate_blas.py
@@ -1,0 +1,53 @@
+import ctypes
+import ctypes.util
+from typing import Optional
+
+BLAS_LIB_NAMES = [
+    "openblas",  # OpenBLAS
+    "mkl_rt",  # Intel MKL (runtime)
+    "Accelerate",  # macOS Accelerate Framework (often found as part of System)
+    "vecLib",  # Also macOS, part of Accelerate
+    "blas",  # Generic
+]
+
+
+def _locate_blas() -> Optional[str]:
+    """
+    Attempts to find a BLAS library.
+
+    This function iterates over a list of potential BLAS library names (e.g., 'openblas',
+    'mkl_rt', etc.). It first checks if the library can be loaded, then tries to find
+    a valid function within the library.
+
+    Returns:
+        str: The name of the BLAS library that was successfully loaded, or None if no
+             library could be found.
+    """
+
+    loaded_lib = None
+    found_lib = None
+
+    for lib_name in BLAS_LIB_NAMES:
+        path = ctypes.util.find_library(lib_name)
+        if path:
+            try:
+                # On Linux, find_library often returns just the name (e.g., 'libblas.so.3')
+                # On macOS, it might be a full path.
+                loaded_lib = ctypes.CDLL(path)
+                found_lib = lib_name
+                break
+            except OSError:
+                pass
+
+    if loaded_lib:
+        try:
+            ssyrk_func = getattr(loaded_lib, "ssyrk_")  # Note the trailing underscore
+        except AttributeError:
+            try:
+                ssyrk_func = getattr(loaded_lib, "cblas_ssyrk")  # cblas interface
+            except AttributeError:
+                pass
+    return found_lib
+
+
+blas_lib_name = _locate_blas()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,7 @@ codespell~=2.2.2
 py-cpuinfo~=9.0.0
 numpy~=1.24.4
 Cython~=3.0.12
+setuptools~=69.5.1
+h5py~=3.9.0
+psutil~=5.9.5
+scipy~=1.10.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,6 @@ flake8~=6.0.0
 flake8-quotes
 cpplint~=1.6.1
 codespell~=2.2.2
+py-cpuinfo~=9.0.0
+numpy~=1.24.4
+Cython~=3.0.12

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ extra_libraries = []
 extra_define_macros = []
 if blas_lib_name:
     extra_libraries.append(blas_lib_name)
-    extra_define_macros.append("BUFFALO_USE_BLAS")
+    extra_define_macros.append(("BUFFALO_USE_BLAS", None))
 
 # NOTE: buffalo needs gcc/g++ for compilation since it uses gnu's parallel sort implementation.
 # Clang does not support parallel sort so far.

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,21 @@ from setuptools import Extension, setup
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "install"))
 from cuda_setup import CUDA, build_ext
+from locate_blas import blas_lib_name
 
 numpy_include_dirs = np.get_include()
-extra_include_dirs = [numpy_include_dirs, "3rd/json11", "3rd/spdlog/include", "3rd/eigen3"]
+extra_include_dirs = [
+    numpy_include_dirs,
+    "3rd/json11",
+    "3rd/spdlog/include",
+    "3rd/eigen3",
+]
 common_srcs = ["lib/misc/log.cc", "lib/algo.cc", "./3rd/json11/json11.cpp"]
+extra_libraries = []
+extra_define_macros = []
+if blas_lib_name:
+    extra_libraries.append(blas_lib_name)
+    extra_define_macros.append("BUFFALO_USE_BLAS")
 
 # NOTE: buffalo needs gcc/g++ for compilation since it uses gnu's parallel sort implementation.
 # Clang does not support parallel sort so far.
@@ -43,7 +54,9 @@ if platform.system().lower() == "darwin":
                 version = matched.group(1)
                 binaries.append((fname, version))
         if not binaries:
-            logging.error("To build buffalo in MacOs, gcc must be installed. Install gcc via `brew install gcc`")
+            logging.error(
+                "To build buffalo in MacOs, gcc must be installed. Install gcc via `brew install gcc`"
+            )
             sys.exit(1)
 
         binaries.sort(key=lambda x: packaging.version.Version(x[1]), reverse=True)
@@ -51,7 +64,9 @@ if platform.system().lower() == "darwin":
 
     ret = subprocess.run(["brew", "--prefix"], capture_output=True)
     if ret.stderr:
-        logging.error("`brew` is required to check and install gcc/g++. Install `brew` first.")
+        logging.error(
+            "`brew` is required to check and install gcc/g++. Install `brew` first."
+        )
         sys.exit(1)
     brew_prefix = ret.stdout.strip().decode()
     binary_dir = pjoin(brew_prefix, "bin")
@@ -74,75 +89,94 @@ if arch == "x86_64":
     if "fma" in flags:
         extended_compile_flags.append("-mfma")
 
-
 extensions = [
-    Extension(name="buffalo.algo._als",
-              sources=["buffalo/algo/_als.pyx", "lib/algo_impl/als/als.cc"] + common_srcs,
-              language="c++",
-              include_dirs=["./include"] + extra_include_dirs,
-              libraries=["gomp"],
-              extra_compile_args=["-fopenmp", "-std=c++14", "-O3"] + extended_compile_flags,
-              define_macros=[("NPY_NO_DEPRECATED_API", "1")]),
-    Extension(name="buffalo.algo._eals",
-              sources=["buffalo/algo/_eals.pyx", "lib/algo_impl/eals/eals.cc"] + common_srcs,
-              language="c++",
-              include_dirs=["./include"] + extra_include_dirs,
-              libraries=["gomp"],
-              extra_compile_args=["-fopenmp", "-std=c++14", "-O3"] + extended_compile_flags,
-              define_macros=[("NPY_NO_DEPRECATED_API", "1")]),
-    Extension(name="buffalo.algo._cfr",
-              sources=["buffalo/algo/_cfr.pyx", "lib/algo_impl/cfr/cfr.cc"] + common_srcs,
-              language="c++",
-              include_dirs=["./include"] + extra_include_dirs,
-              libraries=["gomp"],
-              extra_compile_args=["-fopenmp", "-std=c++14", "-O3"] + extended_compile_flags,
-              define_macros=[("NPY_NO_DEPRECATED_API", "1")]),
-    Extension(name="buffalo.algo._bpr",
-              sources=["buffalo/algo/_bpr.pyx", "lib/algo_impl/bpr/bpr.cc"] + common_srcs,
-              language="c++",
-              include_dirs=["./include"] + extra_include_dirs,
-              libraries=["gomp"],
-              extra_compile_args=["-fopenmp", "-std=c++14", "-O3"] + extended_compile_flags,
-              define_macros=[("NPY_NO_DEPRECATED_API", "1")]),
-    Extension(name="buffalo.algo._plsi",
-              sources=["buffalo/algo/_plsi.pyx", "lib/algo_impl/plsi/plsi.cc"] + common_srcs,
-              language="c++",
-              include_dirs=["./include"] + extra_include_dirs,
-              libraries=["gomp"],
-              extra_compile_args=["-fopenmp", "-std=c++14", "-O3"] + extended_compile_flags,
-              define_macros=[("NPY_NO_DEPRECATED_API", "1")]),
-    Extension(name="buffalo.algo._warp",
-              sources=["buffalo/algo/_warp.pyx", "lib/algo_impl/warp/warp.cc"] + common_srcs,
-              language="c++",
-              include_dirs=["./include"] + extra_include_dirs,
-              libraries=["gomp"],
-              extra_compile_args=["-fopenmp", "-std=c++14", "-O3"] + extended_compile_flags,
-              define_macros=[("NPY_NO_DEPRECATED_API", "1")]),
-    Extension(name="buffalo.algo._w2v",
-              sources=["buffalo/algo/_w2v.pyx", "lib/algo_impl/w2v/w2v.cc"] + common_srcs,
-              language="c++",
-              include_dirs=["./include"] + extra_include_dirs,
-              libraries=["gomp"],
-              extra_compile_args=["-fopenmp", "-std=c++14", "-O3"] + extended_compile_flags,
-              define_macros=[("NPY_NO_DEPRECATED_API", "1")]),
-    Extension(name="buffalo.misc._log",
-              sources=["buffalo/misc/_log.pyx"] + common_srcs,
-              language="c++",
-              include_dirs=["./include"] + extra_include_dirs,
-              libraries=["gomp"],
-              extra_compile_args=["-fopenmp", "-std=c++14", "-O3"] + extended_compile_flags),
-    Extension(name="buffalo.data.fileio",
-              sources=["buffalo/data/fileio.pyx"],
-              language="c++",
-              libraries=["gomp"],
-              extra_compile_args=["-fopenmp", "-std=c++14", "-O3"] + extended_compile_flags),
-    Extension(name="buffalo.parallel._core",
-              sources=["buffalo/parallel/_core.pyx"],
-              language="c++",
-              libraries=["gomp"],
-              include_dirs=extra_include_dirs,
-              extra_compile_args=["-fopenmp", "-std=c++14", "-O3"] + extended_compile_flags,
-              define_macros=[("NPY_NO_DEPRECATED_API", "1")]),
+    Extension(
+        name="buffalo.algo._als",
+        sources=["buffalo/algo/_als.pyx", "lib/algo_impl/als/als.cc"] + common_srcs,
+        language="c++",
+        include_dirs=["./include"] + extra_include_dirs,
+        libraries=["gomp"],
+        extra_compile_args=["-fopenmp", "-std=c++14", "-O3"] + extended_compile_flags,
+        define_macros=[("NPY_NO_DEPRECATED_API", "1")],
+    ),
+    Extension(
+        name="buffalo.algo._eals",
+        sources=["buffalo/algo/_eals.pyx", "lib/algo_impl/eals/eals.cc"] + common_srcs,
+        language="c++",
+        include_dirs=["./include"] + extra_include_dirs,
+        libraries=["gomp"] + extra_libraries,
+        extra_compile_args=["-fopenmp", "-std=c++14", "-O3"] + extended_compile_flags,
+        define_macros=[("NPY_NO_DEPRECATED_API", "1")] + extra_define_macros,
+    ),
+    Extension(
+        name="buffalo.algo._cfr",
+        sources=["buffalo/algo/_cfr.pyx", "lib/algo_impl/cfr/cfr.cc"] + common_srcs,
+        language="c++",
+        include_dirs=["./include"] + extra_include_dirs,
+        libraries=["gomp"],
+        extra_compile_args=["-fopenmp", "-std=c++14", "-O3"] + extended_compile_flags,
+        define_macros=[("NPY_NO_DEPRECATED_API", "1")],
+    ),
+    Extension(
+        name="buffalo.algo._bpr",
+        sources=["buffalo/algo/_bpr.pyx", "lib/algo_impl/bpr/bpr.cc"] + common_srcs,
+        language="c++",
+        include_dirs=["./include"] + extra_include_dirs,
+        libraries=["gomp"],
+        extra_compile_args=["-fopenmp", "-std=c++14", "-O3"] + extended_compile_flags,
+        define_macros=[("NPY_NO_DEPRECATED_API", "1")],
+    ),
+    Extension(
+        name="buffalo.algo._plsi",
+        sources=["buffalo/algo/_plsi.pyx", "lib/algo_impl/plsi/plsi.cc"] + common_srcs,
+        language="c++",
+        include_dirs=["./include"] + extra_include_dirs,
+        libraries=["gomp"],
+        extra_compile_args=["-fopenmp", "-std=c++14", "-O3"] + extended_compile_flags,
+        define_macros=[("NPY_NO_DEPRECATED_API", "1")],
+    ),
+    Extension(
+        name="buffalo.algo._warp",
+        sources=["buffalo/algo/_warp.pyx", "lib/algo_impl/warp/warp.cc"] + common_srcs,
+        language="c++",
+        include_dirs=["./include"] + extra_include_dirs,
+        libraries=["gomp"],
+        extra_compile_args=["-fopenmp", "-std=c++14", "-O3"] + extended_compile_flags,
+        define_macros=[("NPY_NO_DEPRECATED_API", "1")],
+    ),
+    Extension(
+        name="buffalo.algo._w2v",
+        sources=["buffalo/algo/_w2v.pyx", "lib/algo_impl/w2v/w2v.cc"] + common_srcs,
+        language="c++",
+        include_dirs=["./include"] + extra_include_dirs,
+        libraries=["gomp"],
+        extra_compile_args=["-fopenmp", "-std=c++14", "-O3"] + extended_compile_flags,
+        define_macros=[("NPY_NO_DEPRECATED_API", "1")],
+    ),
+    Extension(
+        name="buffalo.misc._log",
+        sources=["buffalo/misc/_log.pyx"] + common_srcs,
+        language="c++",
+        include_dirs=["./include"] + extra_include_dirs,
+        libraries=["gomp"],
+        extra_compile_args=["-fopenmp", "-std=c++14", "-O3"] + extended_compile_flags,
+    ),
+    Extension(
+        name="buffalo.data.fileio",
+        sources=["buffalo/data/fileio.pyx"],
+        language="c++",
+        libraries=["gomp"],
+        extra_compile_args=["-fopenmp", "-std=c++14", "-O3"] + extended_compile_flags,
+    ),
+    Extension(
+        name="buffalo.parallel._core",
+        sources=["buffalo/parallel/_core.pyx"],
+        language="c++",
+        libraries=["gomp"],
+        include_dirs=extra_include_dirs,
+        extra_compile_args=["-fopenmp", "-std=c++14", "-O3"] + extended_compile_flags,
+        define_macros=[("NPY_NO_DEPRECATED_API", "1")],
+    ),
 ]
 
 if CUDA:
@@ -154,14 +188,18 @@ if CUDA:
                 "buffalo/algo/cuda/_als.pyx",
                 "lib/cuda/als/als.cu",
                 "./3rd/json11/json11.cpp",
-                "lib/misc/log.cc"
+                "lib/misc/log.cc",
             ],
             language="c++",
             extra_compile_args=extra_compile_args,
             library_dirs=[CUDA["lib64"]],
             libraries=["cudart", "cublas", "curand"],
             include_dirs=[
-                "./include", numpy_include_dirs, CUDA["include"], "./3rd/json11", "./3rd/spdlog/include"
+                "./include",
+                numpy_include_dirs,
+                CUDA["include"],
+                "./3rd/json11",
+                "./3rd/spdlog/include",
             ],
             define_macros=[("NPY_NO_DEPRECATED_API", "1")],
         )
@@ -173,14 +211,18 @@ if CUDA:
                 "buffalo/algo/cuda/_bpr.pyx",
                 "lib/cuda/bpr/bpr.cu",
                 "./3rd/json11/json11.cpp",
-                "lib/misc/log.cc"
+                "lib/misc/log.cc",
             ],
             language="c++",
             extra_compile_args=extra_compile_args,
             library_dirs=[CUDA["lib64"]],
             libraries=["cudart", "cublas", "curand"],
             include_dirs=[
-                "./include", numpy_include_dirs, CUDA["include"], "./3rd/json11", "./3rd/spdlog/include"
+                "./include",
+                numpy_include_dirs,
+                CUDA["include"],
+                "./3rd/json11",
+                "./3rd/spdlog/include",
             ],
             define_macros=[("NPY_NO_DEPRECATED_API", "1")],
         )

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ extra_libraries = []
 extra_define_macros = []
 if blas_lib_name:
     extra_libraries.append(blas_lib_name)
-    extra_define_macros.append("BUFFALO_USE_BLAS")
+    extra_define_macros.append(("BUFFALO_USE_BLAS",))
 
 # NOTE: buffalo needs gcc/g++ for compilation since it uses gnu's parallel sort implementation.
 # Clang does not support parallel sort so far.


### PR DESCRIPTION
The SSYRK(DSYRK) function implemented in pure C++ language is added as a fallback function.
* In case the BLAS library is available, the build system automatically detects it and links it to buffalo library.
* If the BLAS library hasn't been installed yet, the build system compiles the SSYRK(DSYRK) function implemented in pure C++ as a fallback.
* Supported BLAS libraries:
    - openblas
    - mkl_rt (Intel MKL)
    - blas